### PR TITLE
Whoops bei ausgelagertem Funktionsaufruf

### DIFF
--- a/lib/NavigationArray/BuildArray.php
+++ b/lib/NavigationArray/BuildArray.php
@@ -175,6 +175,9 @@ class BuildArray
      */
     private function initializeStartCategory(): void
     {
+        // Fallback if no mountpoint is available
+        $domain = rex_yrewrite::getDomainByArticleId(rex_article::getCurrentId(), rex_clang::getCurrentId());
+        $this->start = ($domain !== null) ? $domain->getMountId() : 0;
         // get yrewrite mount id if available
         if (is_int($this->start) && $this->start == -1 && rex_addon::get('yrewrite')->isAvailable()) {
             $this->start = rex_yrewrite::getDomainByArticleId(rex_article::getCurrentId(), rex_clang::getCurrentId())->getMountId();


### PR DESCRIPTION
Wenn in yRewrite kein Mountpoint gesetzt ist und die Methode walk() "von außen" aufgerufen wird (also zB. aus der boot.php) dann gab es einen Whoops. Dieser Hotfix prüft entsprechend vorher und setzt die Variable auf 0 statt NULL um den Whoops zu vermeiden.